### PR TITLE
Feature/add tests capabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 dist/
 target/
 build/
+.coverage

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,42 @@
+[FORMAT]
+# Maximum number of characters on a single line.
+max-line-length=90
+
+[MESSAGES CONTROL]
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then re-enable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=C0114,
+        C0115,
+        C0116,
+        C0302,
+        C0411,
+        E0401,
+        E0611,
+        R0904,
+        R0913,
+        W0105,
+        W0201,
+        W0613,
+        W0718,
+        W1514
+
+[BASIC]
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _,
+           fn,
+           ad,
+           App

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+    "recommendations": [
+        "ms-python.isort",
+        "ms-python.black-formatter",
+        "ms-python.pylint",
+        "ms-python.python",
+        "mhutchie.git-graph",
+        "hediet.vscode-drawio"
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Current File",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal",
+            "justMyCode": true
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,38 @@
+{
+    "[python]": {
+        "editor.defaultFormatter": "ms-python.black-formatter",
+        "editor.formatOnSave": true,
+        "editor.codeActionsOnSave": {
+            "source.organizeImports": true
+        },
+    },
+    "isort.args":["--profile", "black"],
+    "pylint.args": [
+        "--disable=C0114",
+        "--disable=C0115",
+        "--disable=C0116",
+        "--disable=C0411",
+        "--disable=E0401",
+        "--disable=E0611",
+        "--disable=R0913",
+        "--disable=W0105",
+        "--disable=W0201",
+        "--disable=W0613",
+        "--disable=W0718",
+        "--disable=W1514",
+        "--max-line-length=89"
+    ],
+    "files.autoSave": "off",
+    "black-formatter.args": [
+        "--line-length=89"
+    ],
+    "git-graph.commitDetailsView.location": "Docked to Bottom",
+    "python.testing.pytestArgs": [
+        "appdaemon"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true,
+    "livePreview.openPreviewTarget": "External Browser",
+    "livePreview.serverRoot": "htmlcov",
+    "terminal.integrated.copyOnSelection": false
+}

--- a/appdaemon_testing/hass_driver.py
+++ b/appdaemon_testing/hass_driver.py
@@ -56,7 +56,9 @@ class HassDriver:
         self._setup_active = False
         self._states: Dict[str, Dict[str, Any]] = defaultdict(lambda: {"state": None})
         self._events: Dict[str, Any] = defaultdict(lambda: [])
-        self._state_spys: Dict[Union[str, None], List[StateSpy]] = defaultdict(lambda: [])
+        self._state_spys: Dict[Union[str, None], List[StateSpy]] = defaultdict(
+            lambda: []
+        )
         self._event_spys: Dict[str, EventSpy] = defaultdict(lambda: [])
         self._run_in_simulations = []
         self._clock_time = 0  # Simulated time in seconds
@@ -108,13 +110,17 @@ class HassDriver:
         yield None
         self._setup_active = False
 
-    def _se_set_state(self, entity_id: str, state, attribute_name="state", **kwargs: Optional[Any]):
+    def _se_set_state(
+        self, entity_id: str, state, attribute_name="state", **kwargs: Optional[Any]
+    ):
         state_entry = self._states[entity_id]
 
         # Update the state entry
         state_entry[attribute_name] = state
 
-    def set_state(self, entity, state, *, attribute_name="state", previous=None, trigger=None) -> None:
+    def set_state(
+        self, entity, state, *, attribute_name="state", previous=None, trigger=None
+    ) -> None:
         """
         Update/set state of an entity.
 
@@ -177,10 +183,14 @@ class HassDriver:
 
         # With matched states, map the provided attribute (if applicable)
         if attribute != "all":
-            matched_states = {eid: state.get(attribute) for eid, state in matched_states.items()}
+            matched_states = {
+                eid: state.get(attribute) for eid, state in matched_states.items()
+            }
 
         if default is not None:
-            matched_states = {eid: state or default for eid, state in matched_states.items()}
+            matched_states = {
+                eid: state or default for eid, state in matched_states.items()
+            }
 
         if fully_qualified:
             return matched_states[entity_id]
@@ -192,7 +202,9 @@ class HassDriver:
             return len(self._state_spys.get(entity))
         return 0
 
-    def _se_listen_state(self, callback, entity=None, attribute=None, new=None, old=None, **kwargs) -> StateSpy:
+    def _se_listen_state(
+        self, callback, entity=None, attribute=None, new=None, old=None, **kwargs
+    ) -> StateSpy:
         spy = StateSpy(
             callback=callback,
             attribute=attribute or "state",
@@ -201,13 +213,19 @@ class HassDriver:
             kwargs=kwargs,
         )
         # WARNING: This works only if function setting callback is called after setup.
-        # It may be required to defer initialize by setting initialize to False in fixture definition
-        # and calling <app>.initialize() after setup
+        # It may be required to defer initialize by setting initialize to False in fixture
+        #  definition and calling <app>.initialize() after setup
         self._state_spys[entity].append(spy)
         if "immediate" in spy.kwargs and spy.kwargs["immediate"] is True:
             state = self._states[entity][spy.attribute]
             if (spy.new is None) or (spy.new == state):
-                spy.callback(entity=entity, attribute="state", new=state, old=old, kwargs=spy.kwargs)
+                spy.callback(
+                    entity=entity,
+                    attribute="state",
+                    new=state,
+                    old=old,
+                    kwargs=spy.kwargs,
+                )
         return spy
 
     def _se_cancel_listen_state(self, handle):
@@ -241,10 +259,11 @@ class HassDriver:
     def _se_run_in(self, callback, delay, **kwargs):
         """
         Simulate an AppDaemon run_in call.
-        return handle
         """
         run_time = self._clock_time + delay
-        self._run_in_simulations.append({"callback": callback, "run_time": run_time, "kwargs": kwargs})
+        self._run_in_simulations.append(
+            {"callback": callback, "run_time": run_time, "kwargs": kwargs}
+        )
         return callback
 
     def get_run_in_simulations(self):

--- a/appdaemon_testing/hass_driver.py
+++ b/appdaemon_testing/hass_driver.py
@@ -218,14 +218,14 @@ class HassDriver:
         )
         # WARNING: This works only if function setting callback is called after setup.
         # It may be required to defer initialize by setting initialize to False in fixture
-        #  definition and calling <app>.initialize() after setup
+        # definition and calling <app>.initialize() after setup
         self._state_spys[entity].append(spy)
         if "immediate" in spy.kwargs and spy.kwargs["immediate"] is True:
             state = self._states[entity][spy.attribute]
             if (spy.new is None) or (spy.new == state):
                 spy.callback(
                     entity=entity,
-                    attribute="state",
+                    attribute=attribute or "state",
                     new=state,
                     old=old,
                     kwargs=spy.kwargs,
@@ -266,7 +266,11 @@ class HassDriver:
         """
         run_time = self._clock_time + delay
         self._run_in_simulations.append(
-            {"callback": callback, "run_time": run_time, "kwargs": kwargs}
+            {
+                "callback": callback,
+                "run_time": run_time,
+                "kwargs": kwargs,
+            }
         )
         return callback
 

--- a/appdaemon_testing/hass_driver.py
+++ b/appdaemon_testing/hass_driver.py
@@ -78,8 +78,12 @@ class HassDriver:
         implementations.
         """
         for meth_name, impl in self._mocks.items():
-            if getattr(hass.Hass, meth_name) is None:
-                raise AssertionError("Attempt to mock non existing method: ", meth_name)
+            try:
+                getattr(hass.Hass, meth_name)
+            except AttributeError as exception:
+                raise AttributeError(
+                    "Attempt to mock non existing method: ", meth_name
+                ) from exception
             _LOGGER.debug("Patching hass.Hass.%s", meth_name)
             setattr(hass.Hass, meth_name, impl)
 

--- a/appdaemon_testing/pytest/__init__.py
+++ b/appdaemon_testing/pytest/__init__.py
@@ -1,5 +1,5 @@
 from functools import wraps
-from typing import Type, TypeVar, Callable
+from typing import Callable, Type, TypeVar
 from unittest import mock
 
 import appdaemon.plugins.hass.hassapi as hass
@@ -16,7 +16,7 @@ def hass_driver() -> HassDriver:
 
     This fixture takes care of ensuring AppDaemon base class methods are patched.
     """
-    hass_driver = HassDriver()
+    hass_driver = HassDriver()  # pylint: disable=W0621
     hass_driver.inject_mocks()
     return hass_driver
 

--- a/appdaemon_testing_tests/pytlint_check.sh
+++ b/appdaemon_testing_tests/pytlint_check.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+test_dir=$(realpath "$(dirname $0)")
+git_dir=$(realpath "${test_dir}/../")
+pushd ${git_dir} > /dev/null
+pylint $(git ls-files '*.py' | grep -v notifier.py | grep -v hass_driver.py) --rcfile ${git_dir}/.pylintrc
+popd > /dev/null

--- a/appdaemon_testing_tests/run_test.sh
+++ b/appdaemon_testing_tests/run_test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+test_dir=$(realpath "$(dirname $0)")
+git_dir=$(realpath "${test_dir}/../")
+echo ">>> ${git_dir}"
+pushd ${git_dir} > /dev/null
+PYTHONPATH=${git_dir} pytest-watch -- --sw --random-order -vs $@
+popd > /dev/null

--- a/appdaemon_testing_tests/show_coverage.sh
+++ b/appdaemon_testing_tests/show_coverage.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+test_dir=$(realpath "$(dirname $0)")
+git_dir=$(realpath "${test_dir}/../")
+appdaemon_testing_dir=$(realpath "${git_dir}/appdaemon_testing/")
+pushd ${git_dir} > /dev/null
+coverage run --source ${appdaemon_testing_dir} -m pytest 
+coverage report -m
+coverage html 
+echo ${git_dir}/htmlcov/index.html
+popd > /dev/null

--- a/appdaemon_testing_tests/test_hass_driver.py
+++ b/appdaemon_testing_tests/test_hass_driver.py
@@ -76,48 +76,48 @@ def test_get_state_domain_with_default(hass_driver):
 @pytest.mark.usefixtures("hass_driver_with_initialized_states")
 def test_listen_state(hass_driver):
     listen_state = hass_driver.get_mock("listen_state")
-    handler1 = mock.Mock()
-    handler2 = mock.Mock()
-    listen_state(handler1, "light.1")
-    listen_state(handler2, "light.1")
+    callback1 = mock.Mock()
+    callback2 = mock.Mock()
+    listen_state(callback1, "light.1")
+    listen_state(callback2, "light.1")
 
-    assert handler1.call_count == 0
-    assert handler2.call_count == 0
+    assert callback1.call_count == 0
+    assert callback2.call_count == 0
 
     hass_driver.set_state("light.1", "off")
 
-    assert handler1.call_count == 0
-    assert handler2.call_count == 0
+    assert callback1.call_count == 0
+    assert callback2.call_count == 0
 
     hass_driver.set_state("light.1", "on")
 
-    handler1.assert_called_once_with("light.1", "state", "off", "on", {})
-    handler2.assert_called_once_with("light.1", "state", "off", "on", {})
+    callback1.assert_called_once_with("light.1", "state", "off", "on", {})
+    callback2.assert_called_once_with("light.1", "state", "off", "on", {})
 
 
 @pytest.mark.usefixtures("hass_driver_with_initialized_states")
 def test_listen_state_attribute(hass_driver):
     listen_state = hass_driver.get_mock("listen_state")
-    handler = mock.Mock()
-    listen_state(handler, "light.1", attribute="linkquality")
+    callback = mock.Mock()
+    listen_state(callback, "light.1", attribute="linkquality")
 
-    assert handler.call_count == 0
+    assert callback.call_count == 0
     hass_driver.set_state("light.1", "on")
-    assert handler.call_count == 0
+    assert callback.call_count == 0
 
     hass_driver.set_state("light.1", 50, attribute_name="linkquality")
-    handler.assert_called_once_with("light.1", "linkquality", 60, 50, {})
+    callback.assert_called_once_with("light.1", "linkquality", 60, 50, {})
 
 
 @pytest.mark.usefixtures("hass_driver_with_initialized_states")
 def test_listen_state_attribute_all(hass_driver):
     listen_state = hass_driver.get_mock("listen_state")
-    handler = mock.Mock()
-    listen_state(handler, "light.1", attribute="all")
+    callback = mock.Mock()
+    listen_state(callback, "light.1", attribute="all")
 
-    assert handler.call_count == 0
+    assert callback.call_count == 0
     hass_driver.set_state("light.1", 75, attribute_name="brightness")
-    handler.assert_called_once_with(
+    callback.assert_called_once_with(
         "light.1",
         None,
         {"state": "off", "linkquality": 60},
@@ -129,25 +129,25 @@ def test_listen_state_attribute_all(hass_driver):
 @pytest.mark.usefixtures("hass_driver_with_initialized_states")
 def test_listen_state_domain(hass_driver):
     listen_state = hass_driver.get_mock("listen_state")
-    handler = mock.Mock()
-    listen_state(handler, "light", attribute="brightness")
+    callback = mock.Mock()
+    listen_state(callback, "light", attribute="brightness")
 
-    assert handler.call_count == 0
+    assert callback.call_count == 0
     hass_driver.set_state("light.2", 75, attribute_name="brightness")
-    handler.assert_called_once_with("light.2", "brightness", 60, 75, {})
+    callback.assert_called_once_with("light.2", "brightness", 60, 75, {})
 
 
 @pytest.mark.usefixtures("hass_driver_with_initialized_states")
 def test_listen_state_with_new(hass_driver):
     listen_state = hass_driver.get_mock("listen_state")
-    handler = mock.Mock()
-    listen_state(handler, "media_player.smart_tv", attribute="source", new="Spotify")
+    callback = mock.Mock()
+    listen_state(callback, "media_player.smart_tv", attribute="source", new="Spotify")
 
     hass_driver.set_state("media_player.smart_tv", "YouTube", attribute_name="source")
-    assert handler.call_count == 0
+    assert callback.call_count == 0
 
     hass_driver.set_state("media_player.smart_tv", "Spotify", attribute_name="source")
-    handler.assert_called_once_with(
+    callback.assert_called_once_with(
         "media_player.smart_tv", "source", "YouTube", "Spotify", {}
     )
 
@@ -155,14 +155,14 @@ def test_listen_state_with_new(hass_driver):
 @pytest.mark.usefixtures("hass_driver_with_initialized_states")
 def test_listen_state_with_old(hass_driver):
     listen_state = hass_driver.get_mock("listen_state")
-    handler = mock.Mock()
-    listen_state(handler, "media_player.smart_tv", attribute="source", old="Spotify")
+    callback = mock.Mock()
+    listen_state(callback, "media_player.smart_tv", attribute="source", old="Spotify")
 
     hass_driver.set_state("media_player.smart_tv", "Spotify", attribute_name="source")
-    assert handler.call_count == 0
+    assert callback.call_count == 0
 
     hass_driver.set_state("media_player.smart_tv", "TV", attribute_name="source")
-    handler.assert_called_once_with(
+    callback.assert_called_once_with(
         "media_player.smart_tv", "source", "Spotify", "TV", {}
     )
 
@@ -170,18 +170,18 @@ def test_listen_state_with_old(hass_driver):
 @pytest.mark.usefixtures("hass_driver_with_initialized_states")
 def test_setup_does_not_trigger_spys(hass_driver):
     listen_state = hass_driver.get_mock("listen_state")
-    handler = mock.Mock()
-    listen_state(handler, "light")
-    listen_state(handler, "light.1", attribute="brightness")
+    callback = mock.Mock()
+    listen_state(callback, "light")
+    listen_state(callback, "light.1", attribute="brightness")
 
     with hass_driver.setup():
         hass_driver.set_state("light.1", "off")
         hass_driver.set_state("light.1", "on")
         hass_driver.set_state("light.1", 50, attribute_name="linkquality")
 
-    assert handler.call_count == 0
+    assert callback.call_count == 0
     hass_driver.set_state("light.1", "off")
-    assert handler.call_count == 1
+    assert callback.call_count == 1
 
 
 class MyApp(hass.Hass):

--- a/appdaemon_testing_tests/test_hass_driver.py
+++ b/appdaemon_testing_tests/test_hass_driver.py
@@ -184,6 +184,14 @@ def test_setup_does_not_trigger_spys(hass_driver):
     assert callback.call_count == 1
 
 
+def test_inject_mock_with_bad_name(hass_driver):
+    with pytest.raises(
+        AttributeError, match="('Attempt to mock non existing method: ', 'bad_name')"
+    ):
+        hass_driver._mocks["bad_name"] = lambda: None
+        hass_driver.inject_mocks()
+
+
 class MyApp(hass.Hass):
     def initialize(self):
         self.log("This is a log")

--- a/appdaemon_testing_tests/test_hass_driver.py
+++ b/appdaemon_testing_tests/test_hass_driver.py
@@ -291,6 +291,31 @@ def test_fire_event(hass_driver, my_app: MyApp):
     assert called
 
 
+def test_run_in(hass_driver, my_app: MyApp):
+    hass_driver.inject_mocks()
+    my_app.initialize()
+
+    hass_driver.set_clock_time(0)
+
+    def callback(name, **kwargs):
+        nonlocal called
+        called = True
+
+    called = False
+    handler = my_app.run_in(callback, 10)
+
+    assert len(hass_driver.get_run_in_simulations()) == 1
+    assert hass_driver.get_run_in_simulations()[0] == handler
+
+    assert not called
+
+    hass_driver.advance_time(5)
+    assert not called
+
+    hass_driver.advance_time(5)
+    assert called
+
+
 @pytest.fixture
 def hass_driver() -> HassDriver:
     hass_driver = HassDriver()

--- a/example/tests/test_living_room_motion.py
+++ b/example/tests/test_living_room_motion.py
@@ -1,10 +1,17 @@
 from unittest import mock
 
-from appdaemon_testing.pytest import automation_fixture
 from apps.living_room_motion import LivingRoomMotion
 
+from appdaemon_testing.pytest import (  # noqa F401; pylint: disable=W0611
+    automation_fixture,
+    hass_driver,
+)
 
-def test_callbacks_are_registered(hass_driver, living_room_motion: LivingRoomMotion):
+
+def test_callbacks_are_registered(
+    hass_driver,  # noqa F811
+    living_room_motion: LivingRoomMotion,  # noqa F811
+):  # pylint: disable=W0621
     listen_state = hass_driver.get_mock("listen_state")
     listen_state.assert_called_once_with(
         living_room_motion.on_motion_detected, "binary_sensor.motion_detected"
@@ -12,8 +19,9 @@ def test_callbacks_are_registered(hass_driver, living_room_motion: LivingRoomMot
 
 
 def test_lights_are_turned_on_when_motion_detected(
-    hass_driver, living_room_motion: LivingRoomMotion
-):
+    hass_driver,  # noqa F811
+    living_room_motion: LivingRoomMotion,  # noqa F811
+):  # pylint: disable=W0621
     with hass_driver.setup():
         hass_driver.set_state("binary_sensor.motion_detected", "off")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+appdaemon==4.4.2
+black==23.7.0
+coverage==7.2.7
+flake8==6.1.0
+pdoc3==0.10.0
+pylint==2.17.5
+pytest-random-order==1.1.0
+pytest-watch==4.2.0


### PR DESCRIPTION
Hello, 

Here is a quite massive pull request...

This pull request is containing additional test capabilities I used to test my `appdaemon` applications (ref [my github](https://github.com/XavierBerger/homeassistant-config) for application and tests) : `cancel_listen_state`,`listen_event`, `fire_event`, `immediate` in callback, `run_in`

I  did add also the build environment I used which is VSCode Server inside HA web interface.

The code has been validated by `blake` and `flake8` as in this repository and also with `pylint` since I use it in all my python dev.   
The code is fully tested with a coverage of 100%.

I hope you will find this pull request interesting. Anyway thanks for you job which allow me to have a coverage of 100% on my code.